### PR TITLE
Update CONTRIBUTING.md with new branch name conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Naming a branch depednds on the changes you are working on and the type of chang
 
 | Type | Pattern | Example |
 |------|---------|---------|
-| New features | `<author-name>/feature/<feature-name>_issue<issue-id>` | `devpal/feature/intorduce-storage_issue122` |
-| Bug Fix | `<author-name>/bug/<bug-name>_issue<issue-id>` | `devpal/bug/auth-error_issue123` |
-| Hotfix (urgent bug fixes) | `<author-name>/hotfix/<bug-name>_issue<issue-id>` | `devpal/hotfix/docusign-regression_issue124` |
-| Maintenance | `<author-name>/maintenance/<maintenance-name>_issue<issue-id>` | `devpal/maintenance/run-integration-tests-in-workflows_issue125` |
+| New features | `feature/<feature-name>` | `feature/intorduce-xyz-delivery` |
+| Bug Fix | `fix/<fix-name>` | `fix/auth-error` |
+| Hotfix (urgent bug fixes) | `hotfix/<fix-name>` | `hotfix/docusign-regression` |
+| Maintenance | `maintenance/<maintenance-name>` | `maintenance/run-integration-tests-in-workflows` |
 
 2. Ensure branch name represents what the branch is about (avoid using names like `fix/bug-fix`, etc)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,13 @@ Naming a branch depednds on the changes you are working on and the type of chang
 
 1. Following branch naming patterns are recommended:
 
-| Type | Pattern | Example |
-|------|---------|---------|
-| New features | `feature/<feature-name>` | `feature/intorduce-xyz-delivery` |
-| Bug Fix | `fix/<fix-name>` | `fix/auth-error` |
-| Hotfix (urgent bug fixes) | `hotfix/<fix-name>` | `hotfix/docusign-regression` |
-| Maintenance | `maintenance/<maintenance-name>` | `maintenance/run-integration-tests-in-workflows` |
+| Type | Pattern | Example | Notes |
+|------|---------|---------|-------|
+| New features | `feature/<feature-name>` | `feature/intorduce-xyz-delivery` | Used for changes that can be categorised as new features |
+| Bug Fix | `fix/<fix-name>` | `fix/auth-error` | Used for changes that can be categorised as bug fixes |
+| Hotfix (urgent bug fixes) | `hotfix/<fix-name>` | `hotfix/docusign-regression` | Used for changes that can be categorised as hotfixs |
+| Maintenance | `maintenance/<maintenance-name>` | `maintenance/run-integration-tests-in-workflows` | Used for changes that can be categorised as internal maintenance that would help in long term |
+| Development | `<author>/<details>` | `devpal/tfa-poc` | Used to manage other tasks that do not fit into above. Often these branches should be converted into one of the above branches (or split into multiple branches of above types) and taken forward |
 
 2. Ensure branch name represents what the branch is about (avoid using names like `fix/bug-fix`, etc)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Naming a branch depednds on the changes you are working on and the type of chang
 | New features | `feature/<feature-name>` | `feature/intorduce-xyz-delivery` | Used for changes that can be categorised as new features |
 | Bug Fix | `fix/<fix-name>` | `fix/auth-error` | Used for changes that can be categorised as bug fixes |
 | Hotfix (urgent bug fixes) | `hotfix/<fix-name>` | `hotfix/docusign-regression` | Used for changes that can be categorised as hotfixs |
+| Security Updates/Fixes | `security/<solution-name>` | `security/suppress-server-headers` | Used for changes that can be categorised as security fixes or enhancements |
 | Maintenance | `maintenance/<maintenance-name>` | `maintenance/run-integration-tests-in-workflows` | Used for changes that can be categorised as internal maintenance that would help in long term |
 | Development | `<author>/<details>` | `devpal/tfa-poc` | Used to manage other tasks that do not fit into above. Often these branches should be converted into one of the above branches (or split into multiple branches of above types) and taken forward |
 
@@ -35,8 +36,7 @@ Follow below points while creating the PR's.
 
 * Ensure PR title hints the changes made in head branch appropriately
 * Ensure PR desciption explains all the changes made in head branch in detail
-* Ensure all commits are linear (no merge commits)
-* Use `Rebase and Merge` option to land PRs once all checks are approved
+* Use `Squash and Merge` option to land PRs once all checks are approved
 
 
 ## Commit message conventions

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,24 @@
+## Hi there 👋
+
+
+Welcome to Flackon, Inc's Git. Here we collaborate and manage our cutting-edge document automation tool Docupilot.
+Docupilot is designed to revolutionize how businesses create and manage documents. Leveraging advanced technology,
+including Python, Django, Node.js, and React.js, it offers a robust, user-friendly platform for automating complex
+document processes. From custom report generation to automated contract creation, DocuPilot simplifies tasks,
+ensuring accuracy and efficiency. Ideal for various industries, it's a game-changer in document generation space.
+
+
+### Contribution guidelines
+
+Read [guidelines on how to contribute](./CONTRIBUTING.md)
+
+
+### Development Setup
+
+Steps to set up the development environment will be outlined in each repo's README. If not, please create an issue in relavant repo.
+
+For a more general approach:
+- install latest Node.js
+- install latest python
+- install latest postgresql
+- setup docker


### PR DESCRIPTION
Simplify branch naming conventions as the current convention contains too many details and most often not necessary.